### PR TITLE
update raw asset to cw20

### DIFF
--- a/bundles/wyndex/src/lib.rs
+++ b/bundles/wyndex/src/lib.rs
@@ -395,8 +395,8 @@ impl WynDex {
                         cw_asset::AssetInfoBase::native(self.wynd_token.to_string()),
                     ),
                     (
-                        RAW_TOKEN.to_string(),
-                        cw_asset::AssetInfoBase::native(self.raw_token.addr_str()?),
+                        raw_asset.to_string(),
+                        cw_asset::AssetInfoBase::cw20(self.raw_token.addr_str()?),
                     ),
                 ],
                 vec![],


### PR DESCRIPTION
Previous update was registering RAW token as Native, so fixed it to be added as cw20.